### PR TITLE
added conditional requests when cached response if fresh

### DIFF
--- a/lib/acorn_cache/cached_response.rb
+++ b/lib/acorn_cache/cached_response.rb
@@ -63,6 +63,17 @@ class Rack::AcornCache
       end
     end
 
+    def not_modified_for?(request)
+      if request.if_none_match && request.if_modified_since
+        request.if_none_match == etag_header &&
+          not_modified_since?(Time.httpdate(request.if_modified_since))
+      elsif request.if_none_match
+        request.if_none_match == etag_header
+      else
+        not_modified_since?(Time.httpdate(request.if_modified_since))
+      end
+    end
+
     def time_to_live
       s_maxage || max_age || (expiration_date - date)
     end
@@ -103,6 +114,10 @@ class Rack::AcornCache
       Time.httpdate(expiration_header)
     end
 
+    def not_modified_since?(time)
+      Time.httpdate(last_modified_header) < time
+    end
+
     def expiration_header
       @expiration_header ||= headers["Expiration"]
     end
@@ -128,6 +143,10 @@ class Rack::AcornCache
     def update!; end
 
     def fresh_for_request?(request)
+      false
+    end
+
+    def not_modified_for?(request)
       false
     end
   end

--- a/lib/acorn_cache/request.rb
+++ b/lib/acorn_cache/request.rb
@@ -41,6 +41,18 @@ class Rack::AcornCache
 
     alias_method :page_rule?, :page_rule
 
+    def if_modified_since
+      env["HTTP_IF_MODIFIED_SINCE"]
+    end
+
+    def if_none_match
+      env["HTTP_IF_NONE_MATCH"]
+    end
+
+    def conditional?
+      if_modified_since || if_none_match
+    end
+
     private
 
     def config

--- a/lib/acorn_cache/version.rb
+++ b/lib/acorn_cache/version.rb
@@ -1,3 +1,3 @@
 module AcornCache
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/cache_controller_test.rb
+++ b/test/cache_controller_test.rb
@@ -72,7 +72,7 @@ class CacheControllerTest < MiniTest::Test
   end
 
   def test_response_when_request_no_cache_false_and_there_is_cached_version_and_not_must_be_revalidated_and_is_fresh_for_request
-    request = stub(no_cache?: false, cache_key: "/", env: {})
+    request = stub(no_cache?: false, cache_key: "/", env: {}, conditional?: false)
     cached_response = stub(must_be_revalidated?: false, fresh_for_request?: true)
     app = stub(call: [200, {}, "foo"])
     cache_maintenance = mock('cache_maintenance')

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,5 +1,6 @@
 require 'acorn_cache/request'
 require 'minitest/autorun'
+require 'time'
 
 class RequestTest < Minitest::Test
   def test_no_cache_delegation
@@ -256,6 +257,35 @@ class RequestTest < Minitest::Test
 
     assert_equal "http://foo.com/bar?baz=true", request.url
     assert_equal "http://foo.com/bar", request.cache_key
+  end
+
+  def test_if_modified_since
+    date = Time.new(2016).httpdate
+    env = { "HTTP_IF_MODIFIED_SINCE" => date }
+    request = Rack::AcornCache::Request.new(env)
+
+    assert_equal date, request.if_modified_since
+  end
+
+  def test_if_none_match
+    env = { "HTTP_IF_NONE_MATCH" => "12345" }
+    request = Rack::AcornCache::Request.new(env)
+
+    assert_equal "12345", request.if_none_match
+  end
+
+
+  def test_conditional
+    env = { "HTTP_IF_NONE_MATCH" => "12345" }
+    request = Rack::AcornCache::Request.new(env)
+
+    assert request.conditional?
+  end
+
+  def test_not_conditional
+    request = Rack::AcornCache::Request.new({})
+
+    refute request.conditional?
   end
 
   def teardown


### PR DESCRIPTION
If a browser cached response is expired but acorn cached version is still fresh, we ought to check etags and last modified headers and return 304 if they match. Otherwise, we should still return the cached version.  This case would be relatively rare but not that hard to account for.

What do you think @perrycarbone ?